### PR TITLE
Fix js console error when locationTypes not defined

### DIFF
--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -4,7 +4,7 @@
 </style>
 <script type="text/javascript">
 cj(document).ready(function(){
-  var locationTypes = {/literal}{$civiPostCodeLookupLocationTypeJson}{literal};
+  var locationTypes = {/literal}{if $civiPostCodeLookupLocationTypeJson}{$civiPostCodeLookupLocationTypeJson}{else}''{/if}{literal};
   var blockId = '';
   var blockNo = '';  
   if (cj('#editrow-street_address-Primary').length > 0  ) {


### PR DESCRIPTION
If you don't specify any location types you get a JS error on the console as it ends up as "var locationTypes = ;"