### PR TITLE
Format postcode before searching

### DIFF
--- a/CRM/Civicrmpostcodelookup/Page/Afd.php
+++ b/CRM/Civicrmpostcodelookup/Page/Afd.php
@@ -2,7 +2,7 @@
 
 require_once 'CRM/Core/Page.php';
 
-class CRM_Civicrmpostcodelookup_Page_Afd extends CRM_Core_Page {
+class CRM_Civicrmpostcodelookup_Page_Afd extends CRM_Civicrmpostcodelookup_Page_Postcode {
 
 	/*
 	 * Function to get the Server URL and login credentials
@@ -41,7 +41,7 @@ class CRM_Civicrmpostcodelookup_Page_Afd extends CRM_Core_Page {
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
-		$postcode = CRM_Utils_Request::retrieve('term', 'String', $this, true);
+		$postcode = self::getPostcode();
 		$number = CRM_Utils_Request::retrieve('number', 'String', $this, false);
 
 		$querystring = self::getAFDCredentials(1);

--- a/CRM/Civicrmpostcodelookup/Page/Afd.php
+++ b/CRM/Civicrmpostcodelookup/Page/Afd.php
@@ -41,7 +41,7 @@ class CRM_Civicrmpostcodelookup_Page_Afd extends CRM_Civicrmpostcodelookup_Page_
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
-		$postcode = self::getPostcode();
+		$postcode = self::getPostcode(TRUE); // FIXME: Check whether API requires space or not
 		$number = CRM_Utils_Request::retrieve('number', 'String', $this, false);
 
 		$querystring = self::getAFDCredentials(1);

--- a/CRM/Civicrmpostcodelookup/Page/Civipostcode.php
+++ b/CRM/Civicrmpostcodelookup/Page/Civipostcode.php
@@ -2,7 +2,7 @@
 
 require_once 'CRM/Core/Page.php';
 
-class CRM_Civicrmpostcodelookup_Page_Civipostcode extends CRM_Core_Page {
+class CRM_Civicrmpostcodelookup_Page_Civipostcode extends CRM_Civicrmpostcodelookup_Page_Postcode {
 
 	/*
 	 * Function to get the Server URL and login credentials
@@ -40,7 +40,7 @@ class CRM_Civicrmpostcodelookup_Page_Civipostcode extends CRM_Core_Page {
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
-		$postcode = CRM_Utils_Request::retrieve('term', 'String', $this, true);
+		$postcode = self::getPostcode();
 		$number = CRM_Utils_Request::retrieve('number', 'String', $this, false);
 
 		$querystring = self::getCivipostcodeCredentials(1);

--- a/CRM/Civicrmpostcodelookup/Page/Civipostcode.php
+++ b/CRM/Civicrmpostcodelookup/Page/Civipostcode.php
@@ -40,7 +40,7 @@ class CRM_Civicrmpostcodelookup_Page_Civipostcode extends CRM_Civicrmpostcodeloo
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
-		$postcode = self::getPostcode();
+		$postcode = self::getPostcode(TRUE);
 		$number = CRM_Utils_Request::retrieve('number', 'String', $this, false);
 
 		$querystring = self::getCivipostcodeCredentials(1);

--- a/CRM/Civicrmpostcodelookup/Page/Experian.php
+++ b/CRM/Civicrmpostcodelookup/Page/Experian.php
@@ -43,7 +43,7 @@ class CRM_PostcodeLookup_Page_Ajax extends CRM_Civicrmpostcodelookup_Page_Postco
     }
 
     public static function search() {
-        $postcode = self::getPostcode();
+        $postcode = self::getPostcode(TRUE); // FIXME: Check whether API requires space or not
         $number = CRM_Utils_Request::retrieve('number', 'String', $this, true);
 
         $qaCapture = self::getQACapture();

--- a/CRM/Civicrmpostcodelookup/Page/Experian.php
+++ b/CRM/Civicrmpostcodelookup/Page/Experian.php
@@ -5,7 +5,7 @@ require_once 'CRM/Core/Page.php';
 // Access the QAS library via the  dependency 'llr_qas_library' module
 require_once '/lib/QASCapture.php';
 
-class CRM_PostcodeLookup_Page_Ajax extends CRM_Core_Page {
+class CRM_PostcodeLookup_Page_Ajax extends CRM_Civicrmpostcodelookup_Page_Postcode {
     static private $qacampture;
 
     public static function getQasCredentials($account_type) {
@@ -43,7 +43,7 @@ class CRM_PostcodeLookup_Page_Ajax extends CRM_Core_Page {
     }
 
     public static function search() {
-        $postcode = CRM_Utils_Request::retrieve('term', 'String', $this, true);
+        $postcode = self::getPostcode();
         $number = CRM_Utils_Request::retrieve('number', 'String', $this, true);
 
         $qaCapture = self::getQACapture();

--- a/CRM/Civicrmpostcodelookup/Page/Postcode.php
+++ b/CRM/Civicrmpostcodelookup/Page/Postcode.php
@@ -1,0 +1,35 @@
+<?php
+
+require_once 'CRM/Core/Page.php';
+
+abstract class CRM_Civicrmpostcodelookup_Page_Postcode extends CRM_Core_Page {
+
+  /**
+   * Get the postcode from the submitted values, with or without space.
+   * @param bool $space
+   *
+   * @return string
+   */
+  protected static function getPostcode($space = FALSE) {
+    $postcode = CRM_Utils_Request::retrieve('term', 'String', $this, true);
+    return self::format($postcode, $space);
+  }
+
+  /**
+   * Format a UK postcode so it has a space before the last digit, or doesn't if $space is FALSE
+   * @param $postcode
+   * @param bool $space
+   *
+   * @return string
+   */
+  protected static function format($postcode, $space) {
+    // Strip non-alpha characters
+    $postcode = preg_replace('/\W/', '', $postcode);
+    if (strlen($postcode) > 4) {
+      ($space) ? $spacerChar = ' ' : $spacerChar = '';
+      return preg_replace('/^(.*)(\d)(.*)/', "$1{$spacerChar}$2$3", $postcode);
+    }
+    return $postcode;
+  }
+
+}

--- a/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
+++ b/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
@@ -41,6 +41,7 @@ class CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere extends CRM_Civicrmpostcod
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
+	  // PostcodeAnywhere API works with postcodes when they have a space and when they don't.
 		$postcode = self::getPostcode();
 
 		$querystring = self::getPostcodeAnywhereCredentials(1);

--- a/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
+++ b/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
@@ -2,7 +2,7 @@
 
 require_once 'CRM/Core/Page.php';
 
-class CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere extends CRM_Core_Page {
+class CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere extends CRM_Civicrmpostcodelookup_Page_Postcode {
 
 	/*
 	 * Function to get the Server URL and login credentials
@@ -41,7 +41,7 @@ class CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere extends CRM_Core_Page {
 	 * Function to get address list based on a Post code
 	 */
 	public static function search() {
-		$postcode = CRM_Utils_Request::retrieve('term', 'String', $this, true);
+		$postcode = self::getPostcode();
 
 		$querystring = self::getPostcodeAnywhereCredentials(1);
 		$querystring = $querystring . "&SearchTerm=" . urlencode($postcode);

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ For having postcode lookup feature in CiviCRM backend and Front end profiles.
 * Install the extension manually in CiviCRM. More details [here](http://wiki.civicrm.org/confluence/display/CRMDOC/Extensions#Extensions-Installinganewextension) about installing extensions in CiviCRM.
 * Configure postcode lookup provider details in Administer >> Postcode Lookup(civicrm/postcodelookup/settings?reset=1)
 
+#### Integration with Drupal Webform
+This drupal module provides integration with Drupal Webform: https://github.com/compucorp/webform_civicrm_postcode
+
 ### Usage ###
 
 * For backend, postcode lookup features is automatically enabled for address fields when adding/editing contacts and configuring event location.

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/veda-consulting/uk.co.vedaconsulting.module.civicrmpostcodelookup</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-09-18</releaseDate>
-  <version>1.4</version>
+  <releaseDate>2017-10-14</releaseDate>
+  <version>1.5</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>

--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -55,6 +55,7 @@ cj(document).ready(function(){
   var addressResultElement = '#addressResult_'+blockNo;
   var addressResultsElement = '#addressResults_'+blockNo;
   var minCharacters = 4;
+  var delay = 200;
 
   var postcodeProvider = '{/literal}{$civiPostCodeLookupProvider}{literal}';
   if (postcodeProvider !== 'civipostcode') {
@@ -72,7 +73,7 @@ cj(document).ready(function(){
         selectFirst: false,
         minChars: minCharacters,
         matchContains: true,
-        delay: 400,
+        delay: delay,
         max: 1000,
         extraParams:{
           term:function () {
@@ -95,7 +96,7 @@ cj(document).ready(function(){
           selectFirst: false,
           minChars: minCharacters,
           matchContains: true,
-          delay: 400,
+          delay: delay,
           max: 1000,
           extraParams:{
             term:function () {
@@ -119,15 +120,15 @@ cj(document).ready(function(){
       minLength: minCharacters,
       data: {postcode: cj( postcodeElement ).val(), number: cj(houseElement).val(), mode: '0'},
       search: function( event, ui ) {
-        //cj('#loaderimage_'+blockNo).show();
+        cj('#loaderimage_'+blockNo).show();
       },
       response: function( event, ui ) {
-        //cj('#loaderimage_'+blockNo).hide();
+        cj('#loaderimage_'+blockNo).hide();
       },
       select: function(event, ui) {
         if (ui.item.id != '') {
           findAddressValues(ui.item.id, blockNo, blockPrefix = '');
-          //cj('#loaderimage_'+blockNo).show();
+          cj('#loaderimage_'+blockNo).show();
         }
         return false;
       },
@@ -147,15 +148,15 @@ cj(document).ready(function(){
         minLength: minCharacters,
         data: {postcode: cj( billingPostcodeElement ).val(), number: cj(houseElement).val(), mode: '0'},
         search: function( event, ui ) {
-          //cj('#loaderimage_'+blockNo).show();
+          cj('#loaderimage_'+blockNo).show();
         },
         response: function( event, ui ) {
-          //cj('#loaderimage_'+blockNo).hide();
+          cj('#loaderimage_'+blockNo).hide();
         },
         select: function(event, ui) {
           if (ui.item.id != '') {
             findAddressValues(ui.item.id, '5', blockPrefix = 'billing_');
-            //cj('#loaderimage_'+blockNo).show();
+            cj('#loaderimage_'+blockNo).show();
           }
           return false;
         },

--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -231,8 +231,9 @@ function setAddressFields(address, blockNo, blockPrefix) {
     cj(cityElement).val(address.town);
     cj(postcodeElement).val(address.postcode);
     if(typeof(address.state_province_id) != "undefined" && address.state_province_id !== null) {
-       cj(countyElement).val(address.state_province_id).trigger("change");
-     }
+       cj(countyElement).val(address.state_province_id);
+    }
+    cj(countyElement).trigger("change");
   }
 }
 </script>

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -46,6 +46,7 @@ cj(document).ready(function() {
   var addressResultElement = '#addressResult_'+blockNo;
   var addressResultsElement = '#addressResults_'+blockNo;
   var minCharacters = 4;
+  var delay = 200;
 
   var postcodeProvider = '{/literal}{$civiPostCodeLookupProvider}{literal}';
   if (postcodeProvider !== 'civipostcode') {
@@ -63,7 +64,7 @@ cj(document).ready(function() {
         selectFirst: false,
         minChars: minCharacters,
         matchContains: true,
-        delay: 400,
+        delay: delay,
         max: 1000,
         extraParams:{
           term:function () {
@@ -84,18 +85,19 @@ cj(document).ready(function() {
     cj(postcodeElement).autocomplete({
         source: sourceUrl,
         minLength: minCharacters,
+        delay: delay,
         data: {postcode: cj( postcodeElement ).val(), number: cj(houseElement).val(), mode: '0'},
         //max: {/literal}{crmSetting name="search_autocomplete_count" group="Search Preferences"}{literal},
         search: function( event, ui ) {
-          //cj('#loaderimage_'+blockNo).show();
+          cj('#loaderimage_'+blockNo).show();
         },
         response: function( event, ui ) {
-          //cj('#loaderimage_'+blockNo).hide();
+          cj('#loaderimage_'+blockNo).hide();
         },
         select: function(event, ui) {
           if (ui.item.id != '') {
             findAddressValues(ui.item.id, blockNo);
-            //cj('#loaderimage_'+blockNo).show();
+            cj('#loaderimage_'+blockNo).show();
           }
           return false;
         },

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -175,8 +175,9 @@ function setAddressFields(address, blockNo) {
          cj(cityElement).val(address.town);
          cj(postcodeElement).val(address.postcode);
          if(typeof(address.state_province_id) != "undefined" && address.state_province_id !== null) {
-           cj(countyElement).val(address.state_province_id).trigger("change");
+           cj(countyElement).val(address.state_province_id);
          }
+         cj(countyElement).trigger("change");
      }
 }
 


### PR DESCRIPTION
Based on feedback at the sprint:
* Format the postcode before searching: This means that postcodes with and without a space work with civipostcode (eg. "AB12 3DE" and "AB123DE").
* Merge PR#16 (Trigger change on county element).
* Create an abstract class for common functionality (currently just postcode formatting).
* Add note to readme about working drupal webform integration.
* Reduce search delay to 200ms and re-enable loading indicator (seems to be a common complaint that it doesn't seem to do anything for ages so this makes it feel more "responsive").
* Update to version 1.5

@veda-consulting Hey Parvez, if you're happy with these changes could you merge and tag a release?  I even updated the info.xml this time :-)