### PR TITLE
Create new permission to access postcode lookups

### DIFF
--- a/civicrmpostcodelookup.php
+++ b/civicrmpostcodelookup.php
@@ -184,3 +184,16 @@ function civicrmpostcodelookup_civicrm_buildForm($formName, &$form) {
       ->addStyleFile('uk.co.vedaconsulting.module.civicrmpostcodelookup', 'css/civipostcode.css', 110, 'page-header');
   }
 }
+
+/**
+ * Implementation of hook_civicrm_permission
+ *
+ * @param array $permissions
+ * @return void
+ */
+function civicrmpostcodelookup_civicrm_permission(&$permissions) {
+  $prefix = ts('CiviCRM') . ': '; // name of extension or module
+  $permissions += array(
+    'access postcode lookup' => $prefix . ts('Access CiviCRM Postcode lookups'),
+  );
+}

--- a/xml/Menu/civicrmpostcodelookup.xml
+++ b/xml/Menu/civicrmpostcodelookup.xml
@@ -9,41 +9,41 @@
   <item>
      <path>civicrm/afd/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Afd::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/afd/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Afd::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/civipostcode/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Civipostcode::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/civipostcode/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Civipostcode::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/experian/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Experian::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/experian/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Experian::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/postcodeanywhere/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/postcodeanywhere/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
User cannot perform postcode lookups if "CiviEvent" component is disabled because the permission for postcode lookups is set to "view event info".

This PR adds a new permission: "access postcode lookup" and requires that permission to perform lookups.