### PR TITLE
Move settings to admin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For having postcode lookup feature in CiviCRM backend and Front end profiles.
 ### Installation ###
 
 * Install the extension manually in CiviCRM. More details [here](http://wiki.civicrm.org/confluence/display/CRMDOC/Extensions#Extensions-Installinganewextension) about installing extensions in CiviCRM.
-* Configure postcode lookup provider details in Administer >> Postcode Lookup(civicrm/postcodelookup/settings?reset=1)
+* Configure postcode lookup provider details in Administer >> Postcode Lookup(civicrm/admin/postcodelookup/settings?reset=1)
 
 #### Integration with Drupal Webform
 This drupal module provides integration with Drupal Webform: https://github.com/compucorp/webform_civicrm_postcode

--- a/civicrmpostcodelookup.php
+++ b/civicrmpostcodelookup.php
@@ -184,3 +184,16 @@ function civicrmpostcodelookup_civicrm_buildForm($formName, &$form) {
       ->addStyleFile('uk.co.vedaconsulting.module.civicrmpostcodelookup', 'css/civipostcode.css', 110, 'page-header');
   }
 }
+
+/**
+ * Implementation of hook_civicrm_permission
+ *
+ * @param array $permissions
+ * @return void
+ */
+function civicrmpostcodelookup_civicrm_permission(&$permissions) {
+  $prefix = ts('CiviCRM') . ': '; // name of extension or module
+  $permissions += array(
+    'access postcode lookup' => $prefix . ts('Access CiviCRM Postcode lookups'),
+  );
+}

--- a/civicrmpostcodelookup.php
+++ b/civicrmpostcodelookup.php
@@ -140,7 +140,7 @@ function civicrmpostcodelookup_civicrm_navigationMenu( &$params ) {
       'attributes' => array (
         'label'      => 'Postcode Lookup',
         'name'       => 'Postcode Lookup',
-        'url'        => 'civicrm/postcodelookup/settings?reset=1',
+        'url'        => 'civicrm/admin/postcodelookup/settings?reset=1',
         'permission' => 'administer CiviCRM',
         'operator'   => NULL,
         'separator'  => TRUE,

--- a/xml/Menu/civicrmpostcodelookup.xml
+++ b/xml/Menu/civicrmpostcodelookup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <menu>
   <item>
-    <path>civicrm/postcodelookup/settings</path>
+    <path>civicrm/admin/postcodelookup/settings</path>
     <page_callback>CRM_Civicrmpostcodelookup_Form_Setting</page_callback>
     <title>Postcode Lookup - Settings</title>
     <access_arguments>administer CiviCRM</access_arguments>

--- a/xml/Menu/civicrmpostcodelookup.xml
+++ b/xml/Menu/civicrmpostcodelookup.xml
@@ -9,41 +9,41 @@
   <item>
      <path>civicrm/afd/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Afd::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/afd/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Afd::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/civipostcode/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Civipostcode::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/civipostcode/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Civipostcode::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/experian/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Experian::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/experian/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_Experian::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/postcodeanywhere/ajax/search</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere::search</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
   <item>
      <path>civicrm/postcodeanywhere/ajax/get</path>
      <page_callback>CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere::getaddress</page_callback>
-     <access_arguments>view event info</access_arguments>
+     <access_arguments>access postcode lookup</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
CiviCRM automatically adds some HTML classes for the admin path so this helps with generic theming and makes it consistent with other settings pages.